### PR TITLE
Downloadable Guide block

### DIFF
--- a/src/styles/components/downloadable-guide-block.scss
+++ b/src/styles/components/downloadable-guide-block.scss
@@ -2,8 +2,6 @@
 
 .downloadable-guide {
 
-  padding: 2.5rem 7rem;
-
   .downloadable-guide--image {
     padding: 0 2.5em;
 
@@ -47,6 +45,8 @@
   }
 
   @include use-up('sm') {
+    padding: 2.5rem 7rem;
+
     .item--text {
       @include item--square;
 

--- a/wp/wp-content/themes/sysart/acf-json/group_5915a89b7fbd0.json
+++ b/wp/wp-content/themes/sysart/acf-json/group_5915a89b7fbd0.json
@@ -132,10 +132,10 @@
             "mime_types": ""
         },
         {
-            "key": "field_5915aab5ee38d",
-            "label": "Guide Download Button Text",
-            "name": "guide_download_button_text",
-            "type": "text",
+            "key": "field_5915aad7ee38e",
+            "label": "Guide Download Button Code",
+            "name": "guide_download_button",
+            "type": "textarea",
             "instructions": "",
             "required": 0,
             "conditional_logic": [
@@ -154,33 +154,9 @@
             },
             "default_value": "",
             "placeholder": "",
-            "prepend": "",
-            "append": "",
-            "maxlength": ""
-        },
-        {
-            "key": "field_5915aad7ee38e",
-            "label": "Guide Download Link",
-            "name": "guide_download_link",
-            "type": "url",
-            "instructions": "",
-            "required": 0,
-            "conditional_logic": [
-                [
-                    {
-                        "field": "field_5915ae82db7d7",
-                        "operator": "==",
-                        "value": "1"
-                    }
-                ]
-            ],
-            "wrapper": {
-                "width": "",
-                "class": "",
-                "id": ""
-            },
-            "default_value": "",
-            "placeholder": ""
+            "maxlength": "",
+            "rows": "",
+            "new_lines": ""
         },
         {
             "key": "field_5915ad49db7d6",
@@ -232,5 +208,5 @@
     "hide_on_screen": "",
     "active": 1,
     "description": "",
-    "modified": 1496134294
+    "modified": 1496210732
 }

--- a/wp/wp-content/themes/sysart/includes/DownloadableGuideBlock.php
+++ b/wp/wp-content/themes/sysart/includes/DownloadableGuideBlock.php
@@ -1,14 +1,13 @@
 <?php
 class DownloadableGuideBlock {
 
-    public function __construct($content_order, $title, $subtitle, $desc, $image_id, $button_text, $url) {
+    public function __construct($content_order, $title, $subtitle, $desc, $image_id, $button_html) {
         $this->content_order = $content_order;
         $this->title = $title;
         $this->subtitle = $subtitle;
         $this->desc = $desc;
         $this->image_id = $image_id;
-        $this->button_text = $button_text;
-        $this->url = $url;
+        $this->button_html = $button_html;
         $img = wp_get_attachment_image($this->image_id, 'large', false, array('class' => 'image image--responsive'));
         $image_first_styles = $this->content_order == 'image_first' ? 'downloadable-guide-image-first' : '';
 
@@ -23,9 +22,7 @@ class DownloadableGuideBlock {
         <h1 class="title title--medium">{$this->subtitle}</h1>
         <p>{$this->desc}</p>
         <div>
-            <a href="{$this->url}" class="button">
-                {$this->button_text}
-            </a>
+            {$this->button_html}
         </div>
     </div>
 </div>

--- a/wp/wp-content/themes/sysart/includes/Utils.php
+++ b/wp/wp-content/themes/sysart/includes/Utils.php
@@ -251,8 +251,7 @@ class Utils {
     $guide_subtitle = get_field('guide_subtitle');
     $guide_description = get_field('guide_description');
     $guide_image = get_field('guide_image');
-    $guide_download_button_text = get_field('guide_download_button_text');
-    $guide_download_link = get_field('guide_download_link');
+    $guide_download_button = get_field('guide_download_button');
 
     if ($guide_visibility
         && $guide_block_content_order
@@ -260,16 +259,14 @@ class Utils {
         && $guide_subtitle
         && $guide_description
         && $guide_image
-        && $guide_download_button_text
-        && $guide_download_link) {
+        && $guide_download_button) {
       $block = new DownloadableGuideBlock(
           $guide_block_content_order,
           $guide_title,
           $guide_subtitle,
           $guide_description,
           $guide_image,
-          $guide_download_button_text,
-          $guide_download_link);
+          $guide_download_button);
       return $block->__toString();
     }
 


### PR DESCRIPTION
Replaced acf-fields for download button text and url with acf-field for download button html, so page-specific CTA button codes from Hubspot are easier to add to pages. Also fixed a padding problem in mobile screens.